### PR TITLE
Fix host processing latency never reported on macOS

### DIFF
--- a/src/platform/macos/display.mm
+++ b/src/platform/macos/display.mm
@@ -52,6 +52,7 @@ namespace platf {
     img->height = (int) CVPixelBufferGetHeight(new_pixel_buffer->buf);
     img->row_pitch = (int) CVPixelBufferGetBytesPerRow(new_pixel_buffer->buf);
     img->pixel_pitch = img->row_pitch / img->width;
+    img->frame_timestamp = std::chrono::steady_clock::now();
 
     old_data_retainer = nullptr;
     return true;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <bitset>
 #include <list>
+#include <map>
 #include <thread>
 
 // lib includes
@@ -370,6 +371,12 @@ namespace video {
 
     avcodec_ctx_t avcodec_ctx;
     std::unique_ptr<platf::avcodec_encode_device_t> device;
+
+    // Capture timestamps of frames in flight inside the encoder, keyed by pts.
+    // Async encoders (e.g. VideoToolbox) return packets for frames sent several
+    // calls ago, so the timestamp must be looked up by the packet's pts rather
+    // than assumed to belong to the frame just submitted.
+    std::map<int64_t, std::chrono::steady_clock::time_point> pending_frame_timestamps;
 
     std::vector<packet_raw_t::replace_t> replacements;
 
@@ -1440,6 +1447,10 @@ namespace video {
     auto &sps = session.sps;
     auto &vps = session.vps;
 
+    if (frame_timestamp) {
+      session.pending_frame_timestamps.emplace(frame_nr, *frame_timestamp);
+    }
+
     // send the frame to the encoder
     auto ret = avcodec_send_frame(ctx.get(), frame);
     if (ret < 0) {
@@ -1493,8 +1504,14 @@ namespace video {
         );
       }
 
-      if (av_packet && av_packet->pts == frame_nr) {
-        packet->frame_timestamp = frame_timestamp;
+      if (av_packet) {
+        auto it = session.pending_frame_timestamps.find(av_packet->pts);
+        if (it != session.pending_frame_timestamps.end()) {
+          packet->frame_timestamp = it->second;
+          // Drop this and any older entries; encoders may skip pts values
+          // (frame drops, resets), and those timestamps will never be claimed.
+          session.pending_frame_timestamps.erase(session.pending_frame_timestamps.begin(), std::next(it));
+        }
       }
 
       packet->replacements = &session.replacements;


### PR DESCRIPTION
Fix host processing latency never reported on macOS

Two halves of one bug: clients showed no host processing latency for
Mac hosts, and RTP timestamps fell back to rate-control estimates
(inflating client jitter buffers).

1. process_frame on macOS never stamped img->frame_timestamp, so the
   capture timestamp was simply absent.

2. Even with a timestamp, encode_avcodec only attached it when the
   returned packet's pts matched the frame just submitted. Async
   encoders like VideoToolbox return packets for frames sent several
   calls earlier, so the check almost never passed and the timestamp
   was silently dropped. Track pending capture timestamps in a
   pts-keyed map and claim them by the returned packet's pts, dropping
   older unclaimed entries (encoders may skip pts values on frame
   drops or resets).

Tested this on a `webos-moonlight` client and works fine :)